### PR TITLE
Add tree visualizer example

### DIFF
--- a/app/tree/page.tsx
+++ b/app/tree/page.tsx
@@ -1,0 +1,11 @@
+import { Tree } from '@/components/tree/Tree'
+import { sampleTree } from '@/lib/sampleTree'
+
+export default function TreePage() {
+  return (
+    <main className="max-w-md mx-auto p-4">
+      <h1 className="text-xl font-semibold mb-4">Tree Visualizer</h1>
+      <Tree data={sampleTree} />
+    </main>
+  )
+}

--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -1,0 +1,16 @@
+"use client"
+import React from 'react'
+import { TreeNodeData } from './types'
+import { TreeNode } from './TreeNode'
+
+export interface TreeProps {
+  data: TreeNodeData[]
+}
+
+export const Tree: React.FC<TreeProps> = ({ data }) => (
+  <ul className="space-y-1">
+    {data.map((node) => (
+      <TreeNode key={node.id} node={node} />
+    ))}
+  </ul>
+)

--- a/components/tree/TreeNode.tsx
+++ b/components/tree/TreeNode.tsx
@@ -1,0 +1,39 @@
+"use client"
+import React, { useState } from 'react'
+import { TreeNodeData } from './types'
+import { Button } from '@/components/ui/button'
+
+export interface TreeNodeProps {
+  node: TreeNodeData
+  depth?: number
+}
+
+export const TreeNode: React.FC<TreeNodeProps> = ({ node, depth = 0 }) => {
+  const [open, setOpen] = useState(false)
+  const hasChildren = node.children && node.children.length > 0
+
+  return (
+    <li className="list-none">
+      <div className="flex items-center gap-2">
+        {hasChildren && (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => setOpen(!open)}
+            aria-label={open ? 'Collapse node' : 'Expand node'}
+          >
+            {open ? '-' : '+'}
+          </Button>
+        )}
+        <span>{node.name}</span>
+      </div>
+      {hasChildren && open && (
+        <ul className="pl-4 border-l ml-3 mt-1 space-y-1">
+          {node.children!.map((child) => (
+            <TreeNode key={child.id} node={child} depth={depth + 1} />
+          ))}
+        </ul>
+      )}
+    </li>
+  )
+}

--- a/components/tree/types.ts
+++ b/components/tree/types.ts
@@ -1,0 +1,5 @@
+export interface TreeNodeData {
+  id: string;
+  name: string;
+  children?: TreeNodeData[];
+}

--- a/lib/sampleTree.ts
+++ b/lib/sampleTree.ts
@@ -1,0 +1,22 @@
+import { TreeNodeData } from '@/components/tree/types'
+
+export const sampleTree: TreeNodeData[] = [
+  {
+    id: '1',
+    name: 'Root',
+    children: [
+      {
+        id: '1-1',
+        name: 'Child 1',
+        children: [
+          { id: '1-1-1', name: 'Grandchild 1' },
+          { id: '1-1-2', name: 'Grandchild 2' },
+        ],
+      },
+      {
+        id: '1-2',
+        name: 'Child 2',
+      },
+    ],
+  },
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "tree-visualizer",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-slot": "^1.2.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.513.0",
@@ -901,6 +902,39 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1228,7 +1262,7 @@
       "version": "19.1.6",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
       "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2233,7 +2267,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.513.0",


### PR DESCRIPTION
## Summary
- add a simple Tree component implemented as client components
- expose a page `/tree` that displays a sample tree
- include sample tree data
- install `@radix-ui/react-slot` for ShadCN buttons

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build` *(fails: Failed to fetch font)*

------
https://chatgpt.com/codex/tasks/task_e_68457bfa4818832a9ff4dcc97b5351a3